### PR TITLE
[pipeline] build and push action updated to v5.

### DIFF
--- a/.github/workflows/pipeline-tornado-mongo-newman.yaml
+++ b/.github/workflows/pipeline-tornado-mongo-newman.yaml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: Build and Push to ACR
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: edotest.azurecr.io/${{ github.repository }}:latest


### PR DESCRIPTION
Still to fix deprecated command used by some actions inside of the pipeline :

annotations (1 warning remained due to Azure login action not updated to Node v20 yet ) here:
https://github.com/mialliedo/tornadomongo-private/actions/runs/8862365112